### PR TITLE
Fix the complication error when using g++

### DIFF
--- a/OptimisticLockCoupling/Tree.cpp
+++ b/OptimisticLockCoupling/Tree.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <algorithm>
+#include <functional>
 #include "Tree.h"
 #include "N.cpp"
 #include "../Epoche.cpp"

--- a/ROWEX/Tree.cpp
+++ b/ROWEX/Tree.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <algorithm>
+#include <functional>
 #include "Tree.h"
 #include "N.cpp"
 #include "../Epoche.cpp"


### PR DESCRIPTION
Fix #2 

The error is caused by the lacking the <functional> header file.