### PR TITLE
Fix new-delete-type-mismatch error in unsychronized ART which leads to memory corruption

### DIFF
--- a/ART/Tree.cpp
+++ b/ART/Tree.cpp
@@ -382,13 +382,13 @@ namespace ART_unsynchronized {
                                 //N::remove(node, k[level]); not necessary
                                 N::change(parentNode, parentKey, secondNodeN);
 
-                                delete node;
+                                N::deleteNode(node);
                             } else {
                                 //N::remove(node, k[level]); not necessary
                                 N::change(parentNode, parentKey, secondNodeN);
                                 secondNodeN->addPrefixBefore(node, secondNodeK);
 
-                                delete node;
+                                N::deleteNode(node);
                             }
                         } else {
                             N::removeA(node, k[level], parentNode, parentKey);


### PR DESCRIPTION
Running the example with `100000 2` (100.000 sparse keys) results in the following assertion error:

`example: ./ART/N.cpp:161: static void ART_unsynchronized::N::deleteChildren(ART_unsynchronized::N*): Assertion  'false' failed.`

This is due to a new-delete-type-mismatch error in the `ART_unsynchronized::Tree::remove` implementation. Deleting the node with the correct size using `N::deleteNode` fixes this issue.